### PR TITLE
Fix stuck 'No items found' message

### DIFF
--- a/js/table-renderer.js
+++ b/js/table-renderer.js
@@ -9,8 +9,15 @@ function renderItems(items) {
     const existingRows = tableContainer.querySelectorAll('.table-row');
     existingRows.forEach(row => row.remove());
 
+    // Clear any previous "no results" message
+    const existingNoResults = tableContainer.querySelector('.no-results');
+    if (existingNoResults) {
+        existingNoResults.remove();
+    }
+
     if (items.length === 0) {
         const noResults = document.createElement('div');
+        noResults.className = 'no-results';
         noResults.style.cssText = 'text-align: center; padding: 40px; color: #6b7280; grid-column: 1 / -1;';
         noResults.textContent = 'No items found';
         tableContainer.appendChild(noResults);


### PR DESCRIPTION
## Summary
- remove previous no-results banner before rendering items
- add a class to the no-results element so it can be easily removed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68826d220df88326916a0b4978320ed9